### PR TITLE
Добавлены переводы для элементов выгрузки пользователей

### DIFF
--- a/client/lang/ru/ac.ts
+++ b/client/lang/ru/ac.ts
@@ -526,6 +526,10 @@ export default {
       },
       sendNotification: {
         sendNotification: 'Отправить уведомление'
+      },
+      unloadUsersMenu: {
+        uploadToExcel: 'Выгрузить в xlsx файл',
+        uploadToCsv: 'Выгрузить в csv файл'
       }
     }
   },


### PR DESCRIPTION
При выгрузке пользователей открывается меню в котором отсутствует перевод.